### PR TITLE
astro-compress

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,8 @@ import tailwind from "@astrojs/tailwind";
 import sitemap from "@astrojs/sitemap";
 import image from "@astrojs/image";
 
+import compress from "astro-compress";
+
 import { SITE } from "./src/config.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -25,6 +27,7 @@ export default defineConfig({
         applyBaseStyles: false,
       },
     }),
+    compress(),
     sitemap(),
     image(),
   ],

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@astrojs/tailwind": "^1.0.0",
     "@tailwindcss/typography": "^0.5.4",
     "astro": "^1.0.0",
+    "astro-compress": "^1.0.6",
     "astro-icon": "^0.7.3",
     "reading-time": "^1.5.0",
     "subfont": "^6.9.0"


### PR DESCRIPTION
This [Astro integration](https://docs.astro.build/en/guides/integrations-guide/) brings compression utilities to your Astro project.
The utility should now automatically compress all your CSS, HTML and JavaScript files in the **dist** folder.
https://github.com/Playform/astro-compress